### PR TITLE
[Course] 수업 생성 api

### DIFF
--- a/src/main/kotlin/com/waffle/areyouhere/api/CourseController.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/api/CourseController.kt
@@ -1,0 +1,52 @@
+package com.waffle.areyouhere.api
+
+import com.waffle.areyouhere.core.attendee.service.dto.AttendeeDto
+import com.waffle.areyouhere.core.course.service.CourseFlowService
+import com.waffle.areyouhere.core.course.service.dto.CourseAndAttendeesCountDto
+import com.waffle.areyouhere.core.session.SessionManager
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.WebSession
+
+@RestController
+@RequestMapping("/api/course")
+class CourseController(
+    private val courseFlowService: CourseFlowService,
+    private val sessionManager: SessionManager,
+) {
+    @PostMapping
+    suspend fun create(@RequestBody courseCreateRequestDto: CourseCreateRequestDto, session: WebSession): ResponseEntity<HttpStatus> {
+        val managerId = sessionManager.login().getManagerIdOrThrow(session)
+        courseFlowService.create(
+            managerId = managerId,
+            name = courseCreateRequestDto.name,
+            description = courseCreateRequestDto.description,
+            attendeeDtos = courseCreateRequestDto.attendees,
+        )
+        return ResponseEntity.status(HttpStatus.OK)
+            .build()
+    }
+
+    @GetMapping
+    suspend fun getAll(session: WebSession): ResponseEntity<CoursesResponseDto> {
+        val managerId = sessionManager.login().getManagerIdOrThrow(session)
+        val response = CoursesResponseDto(courseFlowService.getAllCourseAndAttendeesCountDto(managerId))
+        return ResponseEntity.ok(response)
+    }
+
+    data class CoursesResponseDto(
+        val courses: List<CourseAndAttendeesCountDto>,
+    )
+
+    data class CourseCreateRequestDto(
+        val name: String,
+        val description: String? = null,
+        val attendees: List<AttendeeDto>,
+        val onlyListNameAllowed: Boolean? = true,
+    )
+}

--- a/src/main/kotlin/com/waffle/areyouhere/api/ManagerController.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/api/ManagerController.kt
@@ -1,6 +1,7 @@
 package com.waffle.areyouhere.api
 
 import com.waffle.areyouhere.core.manager.service.ManagerFlowService
+import com.waffle.areyouhere.core.manager.service.dto.ManagerDto
 import com.waffle.areyouhere.core.session.SessionInfo
 import com.waffle.areyouhere.core.session.SessionManager
 import org.springframework.http.HttpStatus
@@ -84,6 +85,13 @@ class ManagerController(
             .build()
     }
 
+    @GetMapping("/me")
+    suspend fun isLogin(session: WebSession): ResponseEntity<ManagerDto> {
+        val managerId = sessionManager.login().getManagerIdOrThrow(session)
+        val response = managerFlowService.get(managerId)
+        return ResponseEntity.ok(response)
+    }
+
     data class LoginRequestDTO(
         val email: String,
         val password: String,
@@ -92,7 +100,7 @@ class ManagerController(
     data class SignUpRequestDTO(
         val email: String,
         val password: String,
-        val nickname: String,
+        val name: String,
     )
 
     data class UpdateRequestDto(

--- a/src/main/kotlin/com/waffle/areyouhere/config/WebConfig.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/config/WebConfig.kt
@@ -15,7 +15,7 @@ class WebConfig : WebFluxConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
             .allowedOrigins(*allowedOrigins)
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
+            .allowedMethods("GET", "POST", "PUT", "DELETE")
             .allowCredentials(true)
             .maxAge(10000)
 

--- a/src/main/kotlin/com/waffle/areyouhere/config/WebConfig.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/config/WebConfig.kt
@@ -13,7 +13,7 @@ class WebConfig : WebFluxConfigurer {
     private lateinit var allowedOrigins: Array<String>
 
     override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/api/**")
+        registry.addMapping("/**")
             .allowedOrigins(*allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
             .allowCredentials(true)

--- a/src/main/kotlin/com/waffle/areyouhere/config/database/DatabaseConfig.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/config/database/DatabaseConfig.kt
@@ -1,10 +1,20 @@
 package com.waffle.areyouhere.config.database
 
+import io.r2dbc.spi.ConnectionFactory
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.r2dbc.config.EnableR2dbcAuditing
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
+import org.springframework.r2dbc.connection.TransactionAwareConnectionFactoryProxy
+import org.springframework.transaction.ReactiveTransactionManager
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 @Configuration
 @EnableR2dbcAuditing
 @EnableTransactionManagement
-class DatabaseConfig
+class DatabaseConfig{
+    @Bean
+    fun reactiveTransactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager {
+        return R2dbcTransactionManager(TransactionAwareConnectionFactoryProxy(connectionFactory))
+    }
+}

--- a/src/main/kotlin/com/waffle/areyouhere/config/database/DatabaseConfig.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/config/database/DatabaseConfig.kt
@@ -2,7 +2,9 @@ package com.waffle.areyouhere.config.database
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.r2dbc.config.EnableR2dbcAuditing
+import org.springframework.transaction.annotation.EnableTransactionManagement
 
 @Configuration
 @EnableR2dbcAuditing
+@EnableTransactionManagement
 class DatabaseConfig

--- a/src/main/kotlin/com/waffle/areyouhere/config/database/DatabaseConfig.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/config/database/DatabaseConfig.kt
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 @Configuration
 @EnableR2dbcAuditing
 @EnableTransactionManagement
-class DatabaseConfig{
+class DatabaseConfig {
     @Bean
     fun reactiveTransactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager {
         return R2dbcTransactionManager(TransactionAwareConnectionFactoryProxy(connectionFactory))

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/model/Attendee.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/model/Attendee.kt
@@ -1,0 +1,20 @@
+package com.waffle.areyouhere.core.attendee.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table(name = "attendee")
+data class Attendee(
+    @Id
+    var id: Long? = null,
+    var name: String,
+    var note: String? = null,
+    var courseId: Long,
+    @CreatedDate
+    var createdAt: Instant? = null,
+    @LastModifiedDate
+    var updatedAt: Instant? = null,
+)

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeBatchRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeBatchRepository.kt
@@ -1,0 +1,25 @@
+package com.waffle.areyouhere.core.attendee.repository
+
+import com.waffle.areyouhere.core.attendee.model.Attendee
+import kotlinx.coroutines.reactive.awaitLast
+import org.springframework.r2dbc.core.DatabaseClient
+import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
+import java.time.Instant
+
+@Repository
+class AttendeeBatchRepository(
+    private val databaseClient: DatabaseClient,
+) {
+    suspend fun insertBatch(attendees: List<Attendee>) {
+        databaseClient.inConnectionMany { connection ->
+            val statement =
+                connection.createStatement("INSERT INTO attendee(name, note, course_id, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)")
+            for (attendee in attendees) {
+                attendee.note?.let { statement.bind(0, attendee.name).bind(1, it).bind(2, attendee.courseId).bind(3, Instant.now()).bind(4, Instant.now()) }
+                    ?: statement.bind(0, attendee.name).bind(2, attendee.courseId).bind(3, Instant.now()).bind(4, Instant.now())
+            }
+            Flux.from(statement.execute())
+        }.awaitLast()
+    }
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeBatchRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeBatchRepository.kt
@@ -1,6 +1,9 @@
 package com.waffle.areyouhere.core.attendee.repository
 
 import com.waffle.areyouhere.core.attendee.model.Attendee
+import com.waffle.areyouhere.util.bindNullable
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.r2dbc.spi.Statement
 import kotlinx.coroutines.reactive.awaitLast
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.stereotype.Repository
@@ -11,14 +14,22 @@ import java.time.Instant
 class AttendeeBatchRepository(
     private val databaseClient: DatabaseClient,
 ) {
+    private val logger = KotlinLogging.logger {}
     suspend fun insertBatch(attendees: List<Attendee>) {
         databaseClient.inConnectionMany { connection ->
             val statement =
                 connection.createStatement("INSERT INTO attendee(name, note, course_id, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)")
             for (attendee in attendees) {
-                attendee.note?.let { statement.bind(0, attendee.name).bind(1, it).bind(2, attendee.courseId).bind(3, Instant.now()).bind(4, Instant.now()) }
-                    ?: statement.bind(0, attendee.name).bind(2, attendee.courseId).bind(3, Instant.now()).bind(4, Instant.now())
+                statement
+                    .bind(0, attendee.name)
+                    .bindNullable(1, attendee.note, String::class.java)
+                    .bind(2, attendee.courseId)
+                    .bind(3, Instant.now())
+                    .bind(4, Instant.now())
+                    .add()
             }
+            statement.fetchSize(attendees.size)
+
             Flux.from(statement.execute())
         }.awaitLast()
     }

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeBatchRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeBatchRepository.kt
@@ -3,7 +3,6 @@ package com.waffle.areyouhere.core.attendee.repository
 import com.waffle.areyouhere.core.attendee.model.Attendee
 import com.waffle.areyouhere.util.bindNullable
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.r2dbc.spi.Statement
 import kotlinx.coroutines.reactive.awaitLast
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.stereotype.Repository
@@ -19,14 +18,16 @@ class AttendeeBatchRepository(
         databaseClient.inConnectionMany { connection ->
             val statement =
                 connection.createStatement("INSERT INTO attendee(name, note, course_id, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)")
-            for (attendee in attendees) {
+            val addLimit = attendees.size - 1
+            attendees.forEachIndexed { index, attendee ->
                 statement
                     .bind(0, attendee.name)
                     .bindNullable(1, attendee.note, String::class.java)
                     .bind(2, attendee.courseId)
                     .bind(3, Instant.now())
                     .bind(4, Instant.now())
-                    .add()
+                if (index < addLimit)
+                    statement.add()
             }
             statement.fetchSize(attendees.size)
 

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/repository/AttendeeRepository.kt
@@ -1,0 +1,10 @@
+package com.waffle.areyouhere.core.attendee.repository
+
+import com.waffle.areyouhere.core.attendee.model.Attendee
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AttendeeRepository : CoroutineCrudRepository<Attendee, Long> {
+    suspend fun countAttendeesByCourseId(courseId: Long): Long
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/service/AttendeeService.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/service/AttendeeService.kt
@@ -1,0 +1,25 @@
+package com.waffle.areyouhere.core.attendee.service
+
+import com.waffle.areyouhere.core.attendee.model.Attendee
+import com.waffle.areyouhere.core.attendee.repository.AttendeeBatchRepository
+import com.waffle.areyouhere.core.attendee.repository.AttendeeRepository
+import org.springframework.stereotype.Service
+
+@Service
+class AttendeeService(
+    private val attendeeRepository: AttendeeRepository,
+    private val attendeeBatchRepository: AttendeeBatchRepository,
+) {
+
+    fun isAttendeeUnique(attendeeNameAndNotes: List<String>): Boolean {
+        return attendeeNameAndNotes.size == attendeeNameAndNotes.toSet().size
+    }
+
+    suspend fun insertBatch(attendees: List<Attendee>) {
+        attendeeBatchRepository.insertBatch(attendees)
+    }
+
+    suspend fun countInCourse(courseId: Long): Long {
+        return attendeeRepository.countAttendeesByCourseId(courseId)
+    }
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/attendee/service/dto/AttendeeDto.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/attendee/service/dto/AttendeeDto.kt
@@ -1,0 +1,6 @@
+package com.waffle.areyouhere.core.attendee.service.dto
+
+data class AttendeeDto(
+    val name: String,
+    val note: String,
+)

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/model/Course.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/model/Course.kt
@@ -1,0 +1,21 @@
+package com.waffle.areyouhere.core.course.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table("course")
+data class Course(
+    @Id
+    var id: Long? = null,
+    var name: String,
+    var description: String? = null,
+    var allowOnlyRegistered: Boolean,
+    var managerId: Long,
+    @CreatedDate
+    var createdAt: Instant? = null,
+    @LastModifiedDate
+    var updatedAt: Instant? = null,
+)

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/repository/CourseRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/repository/CourseRepository.kt
@@ -1,0 +1,10 @@
+package com.waffle.areyouhere.core.course.repository
+
+import com.waffle.areyouhere.core.course.model.Course
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CourseRepository : CoroutineCrudRepository<Course, Long> {
+    suspend fun findByManagerId(managerId: Long): List<Course>
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseFlowService.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseFlowService.kt
@@ -29,7 +29,7 @@ class CourseFlowService(
         )
         val savedCourse = courseService.save(course)
 
-        val attendees = if(attendeeDtos.isNotEmpty()) {
+        val attendees = if (attendeeDtos.isNotEmpty()) {
             attendeeDtos.map {
                 Attendee(
                     name = it.name,

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseFlowService.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseFlowService.kt
@@ -29,14 +29,17 @@ class CourseFlowService(
         )
         val savedCourse = courseService.save(course)
 
-        val attendees = attendeeDtos.map {
-            Attendee(
-                name = it.name,
-                note = it.note,
-                courseId = savedCourse.id!!,
-            )
-        }
-        attendeeService.insertBatch(attendees)
+        val attendees = if(attendeeDtos.isNotEmpty()) {
+            attendeeDtos.map {
+                Attendee(
+                    name = it.name,
+                    note = it.note,
+                    courseId = savedCourse.id!!,
+                )
+            }
+        } else null
+
+        attendees?.let { attendeeService.insertBatch(it) }
     }
 
     @Transactional(readOnly = true)
@@ -49,7 +52,7 @@ class CourseFlowService(
                 description = it.description,
                 allowOnlyRegistered = it.allowOnlyRegistered,
                 // FIXME: 쿼리 하나로?
-                attendeesCount = attendeeService.countInCourse(it.id!!),
+                attendees = attendeeService.countInCourse(it.id!!),
             )
         }
     }

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseFlowService.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseFlowService.kt
@@ -1,0 +1,56 @@
+package com.waffle.areyouhere.core.course.service
+
+import com.waffle.areyouhere.core.attendee.model.Attendee
+import com.waffle.areyouhere.core.attendee.service.AttendeeService
+import com.waffle.areyouhere.core.attendee.service.dto.AttendeeDto
+import com.waffle.areyouhere.core.course.model.Course
+import com.waffle.areyouhere.core.course.service.dto.CourseAndAttendeesCountDto
+import com.waffle.areyouhere.crossConcern.error.AttendeeNotUniqueException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CourseFlowService(
+    private val courseService: CourseService,
+    private val attendeeService: AttendeeService,
+) {
+
+    @Transactional
+    suspend fun create(managerId: Long, name: String, description: String?, attendeeDtos: List<AttendeeDto>) {
+        if (attendeeService.isAttendeeUnique(attendeeDtos.map { it.name + it.note }).not()) {
+            throw AttendeeNotUniqueException
+        }
+
+        val course = Course(
+            name = name,
+            description = description,
+            allowOnlyRegistered = true,
+            managerId = managerId,
+        )
+        val savedCourse = courseService.save(course)
+
+        val attendees = attendeeDtos.map {
+            Attendee(
+                name = it.name,
+                note = it.note,
+                courseId = savedCourse.id!!,
+            )
+        }
+        attendeeService.insertBatch(attendees)
+    }
+
+    @Transactional(readOnly = true)
+    suspend fun getAllCourseAndAttendeesCountDto(managerId: Long): List<CourseAndAttendeesCountDto> {
+        val courses = courseService.getAll(managerId)
+        return courses.map {
+            CourseAndAttendeesCountDto(
+                id = it.id!!,
+                name = it.name,
+                description = it.description,
+                allowOnlyRegistered = it.allowOnlyRegistered,
+                // FIXME: 쿼리 하나로?
+                attendeesCount = attendeeService.countInCourse(it.id!!),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseService.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/service/CourseService.kt
@@ -1,0 +1,17 @@
+package com.waffle.areyouhere.core.course.service
+
+import com.waffle.areyouhere.core.course.model.Course
+import com.waffle.areyouhere.core.course.repository.CourseRepository
+import org.springframework.stereotype.Service
+
+@Service
+class CourseService(
+    private val courseRepository: CourseRepository,
+) {
+    suspend fun getAll(managerId: Long): List<Course> {
+        return courseRepository.findByManagerId(managerId)
+    }
+    suspend fun save(course: Course): Course {
+        return courseRepository.save(course)
+    }
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/service/dto/CourseAndAttendeesCountDto.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/service/dto/CourseAndAttendeesCountDto.kt
@@ -1,0 +1,19 @@
+package com.waffle.areyouhere.core.course.service.dto
+
+import com.waffle.areyouhere.core.course.model.Course
+
+data class CourseAndAttendeesCountDto(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val allowOnlyRegistered: Boolean,
+    val attendeesCount: Long,
+) {
+    constructor(course: Course, attendeesCount: Long) : this(
+        id = course.id!!,
+        name = course.name,
+        description = course.description,
+        allowOnlyRegistered = course.allowOnlyRegistered,
+        attendeesCount = attendeesCount,
+    )
+}

--- a/src/main/kotlin/com/waffle/areyouhere/core/course/service/dto/CourseAndAttendeesCountDto.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/course/service/dto/CourseAndAttendeesCountDto.kt
@@ -7,13 +7,13 @@ data class CourseAndAttendeesCountDto(
     val name: String,
     val description: String?,
     val allowOnlyRegistered: Boolean,
-    val attendeesCount: Long,
+    val attendees: Long,
 ) {
     constructor(course: Course, attendeesCount: Long) : this(
         id = course.id!!,
         name = course.name,
         description = course.description,
         allowOnlyRegistered = course.allowOnlyRegistered,
-        attendeesCount = attendeesCount,
+        attendees = attendeesCount,
     )
 }

--- a/src/main/kotlin/com/waffle/areyouhere/core/manager/service/ManagerFlowService.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/manager/service/ManagerFlowService.kt
@@ -4,6 +4,7 @@ import com.waffle.areyouhere.core.email.EmailService
 import com.waffle.areyouhere.core.email.model.MessageTemplate
 import com.waffle.areyouhere.core.manager.model.EmailCodeRepository
 import com.waffle.areyouhere.core.manager.model.Manager
+import com.waffle.areyouhere.core.manager.service.dto.ManagerDto
 import com.waffle.areyouhere.crossConcern.error.EmailNotSentYetException
 import com.waffle.areyouhere.crossConcern.error.ManagerNotExistsException
 import com.waffle.areyouhere.crossConcern.error.NotVerifiedCodeException
@@ -83,6 +84,11 @@ class ManagerFlowService(
             EmailCodeRepository.EmailCode.Key(email),
             EmailCodeRepository.EmailCode.Value(code, true),
         )
+    }
+
+    @Transactional(readOnly = true)
+    suspend fun get(managerId: Long): ManagerDto {
+        return ManagerDto(managerService.findById(managerId))
     }
 
     private final val codeLength = 6

--- a/src/main/kotlin/com/waffle/areyouhere/core/manager/service/dto/ManagerDto.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/manager/service/dto/ManagerDto.kt
@@ -1,0 +1,13 @@
+package com.waffle.areyouhere.core.manager.service.dto
+
+import com.waffle.areyouhere.core.manager.model.Manager
+
+data class ManagerDto(
+    val email: String,
+    val name: String,
+) {
+    constructor(manager: Manager) : this(
+        email = manager.email,
+        name = manager.name,
+    )
+}

--- a/src/main/kotlin/com/waffle/areyouhere/crossConcern/error/AreYouHereException.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/crossConcern/error/AreYouHereException.kt
@@ -12,3 +12,4 @@ object AlreadyExistsEmailException : AreYouHereException(ErrorType.RESPONSE_CONF
 object EmailNotSentYetException : AreYouHereException(ErrorType.BAD_REQUEST, displayMessage = "이메일을 먼저 보낸 후 인증을 시도해주세요.")
 object VerificationCodeNotMatchedException : AreYouHereException(ErrorType.BAD_REQUEST, displayMessage = "코드가 일치하지 않습니다.")
 object NotVerifiedCodeException : AreYouHereException(ErrorType.UNAUTHORIZED, displayMessage = "코드를 먼저 인증해주세요.")
+object AttendeeNotUniqueException : AreYouHereException(ErrorType.RESPONSE_CONFLICT, displayMessage = "중복되는 수강자의 이름의 note를 변경해주세요.")

--- a/src/main/kotlin/com/waffle/areyouhere/crossConcern/error/ErrorWebFilter.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/crossConcern/error/ErrorWebFilter.kt
@@ -14,7 +14,7 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 import reactor.netty.channel.AbortedException
 
-@Order(Integer.MAX_VALUE)
+@Order(Integer.MIN_VALUE)
 @Component
 class ErrorWebFilter(
     private val objectMapper: ObjectMapper,

--- a/src/main/kotlin/com/waffle/areyouhere/crossConcern/error/ErrorWebFilter.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/crossConcern/error/ErrorWebFilter.kt
@@ -2,6 +2,7 @@ package com.waffle.areyouhere.crossConcern.error
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.core.annotation.Order
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
@@ -13,6 +14,7 @@ import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 import reactor.netty.channel.AbortedException
 
+@Order(Integer.MAX_VALUE)
 @Component
 class ErrorWebFilter(
     private val objectMapper: ObjectMapper,
@@ -25,6 +27,7 @@ class ErrorWebFilter(
             val (httpStatus, errorBody) = when (throwable) {
                 is AreYouHereException -> throwable.error.httpStatus to makeErrorBody(throwable)
                 is ResponseStatusException -> {
+                    logger.info { "Unexpected error $throwable" }
                     logger.info { throwable.printStackTrace() }
                     throwable.statusCode to makeErrorBody(
                         AreYouHereException(errorMessage = throwable.body.title ?: ErrorType.DEFAULT_ERROR.errorMessage),
@@ -34,6 +37,7 @@ class ErrorWebFilter(
                 else -> {
                     // TODO: 슬랙 메시지 전송
                     logger.error { "Unexpected error $throwable" }
+                    logger.error { throwable.printStackTrace() }
                     HttpStatus.INTERNAL_SERVER_ERROR to makeErrorBody(AreYouHereException())
                 }
             }

--- a/src/main/kotlin/com/waffle/areyouhere/crossConcern/session/SessionFilter.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/crossConcern/session/SessionFilter.kt
@@ -25,14 +25,9 @@ class SessionFilter(
     private val logger = KotlinLogging.logger {}
     private val basePattern = PathPatternParser().parse("/api/**")
 
-    // FIXME: 프론트와 url 통일해서 regexp로 대응
     private val excludePatterns = listOf(
-        PathPatternParser().parse("/api/auth/login"),
-        PathPatternParser().parse("/api/auth/signup"),
-        PathPatternParser().parse("/api/auth/email"),
-        PathPatternParser().parse("/api/auth/email-availability"),
-        PathPatternParser().parse("/api/auth/verification"),
-        PathPatternParser().parse("/api/attendance"),
+        PathPatternParser().parse("/api/auth/(login|me|signup|email|email-availability|verification)"),
+        PathPatternParser().parse("/api/attendance")
     )
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
@@ -64,9 +59,8 @@ class SessionFilter(
     }
 
     private fun shouldApplyFilter(exchange: ServerWebExchange): Boolean {
-        val isOptionsMethod = exchange.request.method == org.springframework.http.HttpMethod.OPTIONS
         val path = exchange.request.path.pathWithinApplication()
-        return basePattern.matches(path) && excludePatterns.none { it.matches(path) } && !isOptionsMethod
+        return basePattern.matches(path) && excludePatterns.none { it.matches(path) }
     }
 
     private fun logRequest(request: ServerHttpRequest) {

--- a/src/main/kotlin/com/waffle/areyouhere/crossConcern/session/SessionFilter.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/crossConcern/session/SessionFilter.kt
@@ -16,7 +16,7 @@ import org.springframework.web.util.pattern.PathPatternParser
 import reactor.core.publisher.Mono
 import java.util.concurrent.TimeUnit
 
-@Order(Integer.MIN_VALUE)
+@Order(Integer.MAX_VALUE)
 @Component
 class SessionFilter(
     private val meterRegistry: MeterRegistry,
@@ -27,7 +27,7 @@ class SessionFilter(
 
     private val excludePatterns = listOf(
         PathPatternParser().parse("/api/auth/(login|me|signup|email|email-availability|verification)"),
-        PathPatternParser().parse("/api/attendance")
+        PathPatternParser().parse("/api/attendance"),
     )
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
@@ -59,8 +59,9 @@ class SessionFilter(
     }
 
     private fun shouldApplyFilter(exchange: ServerWebExchange): Boolean {
+        val isOptionsMethod = exchange.request.method == org.springframework.http.HttpMethod.OPTIONS
         val path = exchange.request.path.pathWithinApplication()
-        return basePattern.matches(path) && excludePatterns.none { it.matches(path) }
+        return basePattern.matches(path) && excludePatterns.none { it.matches(path) } && isOptionsMethod.not()
     }
 
     private fun logRequest(request: ServerHttpRequest) {

--- a/src/main/kotlin/com/waffle/areyouhere/crossConcern/session/SessionFilter.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/crossConcern/session/SessionFilter.kt
@@ -1,18 +1,13 @@
 package com.waffle.areyouhere.crossConcern.session
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.waffle.areyouhere.crossConcern.error.AreYouHereException
-import com.waffle.areyouhere.crossConcern.error.ErrorType
+import com.waffle.areyouhere.core.session.SessionManager.Companion.SESSION_KEY
 import com.waffle.areyouhere.crossConcern.error.UnAuthorizeException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Metrics
-import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatusCode
-import org.springframework.http.MediaType
+import org.springframework.core.annotation.Order
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.stereotype.Component
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
@@ -21,10 +16,10 @@ import org.springframework.web.util.pattern.PathPatternParser
 import reactor.core.publisher.Mono
 import java.util.concurrent.TimeUnit
 
+@Order(Integer.MIN_VALUE)
 @Component
 class SessionFilter(
     private val meterRegistry: MeterRegistry,
-    private val objectMapper: ObjectMapper,
 ) : WebFilter {
 
     private val logger = KotlinLogging.logger {}
@@ -44,7 +39,7 @@ class SessionFilter(
         return measureLatency().flatMap {
             logRequest(exchange.request)
             processFilterLogic(exchange, chain)
-        }.onErrorResume { handleFilterError(it, exchange) }
+        }
     }
 
     private fun processFilterLogic(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
@@ -62,15 +57,16 @@ class SessionFilter(
     }
 
     private fun checkSessionAttributes(session: WebSession) {
-        if (session.getAttribute<Any>("user") == null) {
+        if (session.getAttribute<Any>(SESSION_KEY) == null) {
             throw UnAuthorizeException
         }
         meterRegistry.counter("session.validation.success").increment()
     }
 
     private fun shouldApplyFilter(exchange: ServerWebExchange): Boolean {
+        val isOptionsMethod = exchange.request.method == org.springframework.http.HttpMethod.OPTIONS
         val path = exchange.request.path.pathWithinApplication()
-        return basePattern.matches(path) && excludePatterns.none { it.matches(path) }
+        return basePattern.matches(path) && excludePatterns.none { it.matches(path) } && !isOptionsMethod
     }
 
     private fun logRequest(request: ServerHttpRequest) {
@@ -80,42 +76,9 @@ class SessionFilter(
         }
     }
 
-    private fun handleFilterError(error: Throwable, exchange: ServerWebExchange): Mono<Void> {
-        val (httpStatus, errorBody) = when (error) {
-            is AreYouHereException -> error.error.httpStatus to makeErrorBody(error)
-            is ResponseStatusException -> {
-                logger.info { error.printStackTrace() }
-                error.statusCode to makeErrorBody(
-                    AreYouHereException(errorMessage = error.body.title ?: ErrorType.DEFAULT_ERROR.errorMessage),
-                )
-            }
-            else -> {
-                logger.error { "Unexpected error $error" }
-                HttpStatus.INTERNAL_SERVER_ERROR to makeErrorBody(AreYouHereException())
-            }
-        }
-        return exchange.respondWith(httpStatus, errorBody)
-    }
-
-    private fun makeErrorBody(exception: AreYouHereException) =
-        ErrorBody(exception.error.errorCode, exception.errorMessage, exception.displayMessage)
-
-    private fun ServerWebExchange.respondWith(status: HttpStatusCode, errorBody: ErrorBody): Mono<Void> {
-        response.statusCode = status
-        response.headers.contentType = MediaType.APPLICATION_JSON
-        val buffer = response.bufferFactory().wrap(objectMapper.writeValueAsBytes(errorBody))
-        return response.writeWith(Mono.just(buffer))
-    }
-
     private fun measureLatency() = Mono.fromCallable { System.nanoTime() }
         .doOnNext { start ->
             Metrics.timer("filter.latency")
                 .record(System.nanoTime() - start, TimeUnit.NANOSECONDS)
         }
 }
-
-private data class ErrorBody(
-    val errcode: Long,
-    val message: String,
-    val displayMessage: String,
-)

--- a/src/main/kotlin/com/waffle/areyouhere/util/StatementExt.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/util/StatementExt.kt
@@ -1,0 +1,11 @@
+package com.waffle.areyouhere.util
+
+import io.r2dbc.spi.Statement
+
+fun Statement.bindNullable(index: Int, value: Any?, type: Class<*>) = apply {
+    if (value != null) {
+        bind(index, value)
+    } else {
+        bindNull(index, type)
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -20,7 +20,6 @@ spring:
     password:
     driver-class-name: org.h2.Driver
     enabled: true
-    drop-first: true
   data:
     redis:
       host: localhost

--- a/src/main/resources/liquibase/002-create-table-course.sql
+++ b/src/main/resources/liquibase/002-create-table-course.sql
@@ -4,7 +4,7 @@
 CREATE TABLE course (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
-    description TEXT NULL,
+    description TEXT NULL DEFAULT NULL,
     allow_only_registered BOOLEAN NOT NULL,
     manager_id BIGINT NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,

--- a/src/main/resources/liquibase/004-create-table-attendee.sql
+++ b/src/main/resources/liquibase/004-create-table-attendee.sql
@@ -4,7 +4,7 @@
 CREATE TABLE attendee (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
-    note TEXT NULL,
+    note TEXT NULL DEFAULT NULL,
     course_id BIGINT NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
     updated_at TIMESTAMP(6) NOT NULL


### PR DESCRIPTION
- 수업 생성 api
- batch insert를 통한 attendee 삽입
- 사실 batch보단 bulk라는 말이 더 어울리나 싶긴 합니다. (spring batch를 사용하는게 아니라 그냥 단건 쿼리 insert 효율화라서..)
- batchinsertRepository를 제공하고 해당 repository를 상속해서 조금 더 간단하게 구현하는 것이 가능할 것 같은데, 그건 추후에 진행할 예정입니다.

```
@Transactional(readOnly = true)
    suspend fun getAllCourseAndAttendeesCountDto(managerId: Long): List<CourseAndAttendeesCountDto> {
        val courses = courseService.getAll(managerId)
        return courses.map {
            CourseAndAttendeesCountDto(
                id = it.id!!,
                name = it.name,
                description = it.description,
                allowOnlyRegistered = it.allowOnlyRegistered,
                // FIXME: 쿼리 하나로?
                attendees = attendeeService.countInCourse(it.id!!),
            )
        }
    }
```
위 쿼리가 n+1 문제가 있긴한데 전체 course 수가 많지 않아 단건쿼리를 당장은 할 필요가 없다고 생각합니다.
group by가 필요한 쿼리이기에 native query를 짜거나 dsl 도입이 필요한데, 
native query는 선호하지 않아 적절한 dsl 검토 후 수정 예정입니다.
    